### PR TITLE
fix: Apply explicit scaled font for macOS font size settings

### DIFF
--- a/MeshHessen/MeshHessenApp.swift
+++ b/MeshHessen/MeshHessenApp.swift
@@ -39,6 +39,7 @@ struct MeshHessenApp: App {
         WindowGroup {
             MainView()
                 .frame(minWidth: 800, minHeight: 500)
+                .font(SettingsService.shared.scaledBodyFont)
                 .environment(\.appState, coordinator.appState)
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environment(\.persistenceController, persistenceController)
@@ -78,6 +79,7 @@ struct MeshHessenApp: App {
         // MARK: - Direct Messages Window
         Window("Direct Messages", id: "dm") {
             DMWindowView()
+                .font(SettingsService.shared.scaledBodyFont)
                 .environment(\.appState, coordinator.appState)
                 .environment(\.managedObjectContext, persistenceController.container.viewContext)
                 .environment(\.persistenceController, persistenceController)

--- a/MeshHessen/Services/SettingsService.swift
+++ b/MeshHessen/Services/SettingsService.swift
@@ -56,6 +56,14 @@ final class SettingsService {
         }
     }
 
+    /// Scaled default body font for macOS, where `DynamicTypeSize` is often ignored.
+    /// Base size 13 pt (macOS system body) ± 2 pt per step.
+    var scaledBodyFont: Font {
+        let baseSize: CGFloat = 13
+        let pointSize = baseSize + CGFloat(fontSizeStep) * 2
+        return .system(size: max(9, pointSize))
+    }
+
     // MARK: - Connection
     var lastComPort: String {
         get { defaults.string(forKey: "lastComPort") ?? "" }


### PR DESCRIPTION
## Summary
- macOS `DynamicTypeSize` alone does not reliably affect all SwiftUI controls
- Added `scaledBodyFont` computed property to `SettingsService` (base 13pt ± 2pt per step)
- Applied `.font()` modifier at the window level for both main and DM windows
- Text now visibly changes size when the user adjusts XS through XXL

Fixes #6

## Test plan
- [ ] Open Settings → General → Text Size
- [ ] Click the increase/decrease buttons and verify text in the chat view changes size
- [ ] Try ⌘+ / ⌘- shortcuts
- [ ] Verify XS through XXL all produce visibly different text sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)