### PR TITLE
feat: Add delete messages button for channels and DMs

### DIFF
--- a/MeshHessen/AppState.swift
+++ b/MeshHessen/AppState.swift
@@ -116,6 +116,18 @@ final class AppState {
         channelUnreadCounts[index] = 0
     }
 
+    /// Remove all in-memory messages for a given channel.
+    func clearChannelMessages(_ index: Int) {
+        channelMessages[index]?.removeAll()
+        allMessages.removeAll { $0.channelIndex == index }
+        channelUnreadCounts[index] = 0
+    }
+
+    /// Remove all in-memory messages for a DM conversation.
+    func clearDMMessages(for nodeId: UInt32) {
+        dmConversations[nodeId]?.messages.removeAll()
+    }
+
     func addOrUpdateDM(_ msg: MessageItem, myNodeId: UInt32) {
         let partnerId = msg.fromId == myNodeId ? msg.toId : msg.fromId
         let partnerName = nodes[partnerId]?.name ?? msg.from

--- a/MeshHessen/Views/ChannelChatView.swift
+++ b/MeshHessen/Views/ChannelChatView.swift
@@ -8,6 +8,7 @@ struct ChannelChatView: View {
     let channelIndex: Int
     @State private var messageText = ""
     @State private var isSending = false
+    @State private var showDeleteConfirmation = false
     @FocusState private var inputFocused: Bool
 
     private var messages: [MessageItem] {
@@ -16,6 +17,22 @@ struct ChannelChatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button {
+                    showDeleteConfirmation = true
+                } label: {
+                    Label("Nachrichten löschen", systemImage: "trash")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .disabled(messages.isEmpty)
+                .help("Alle Nachrichten in diesem Kanal löschen")
+                .padding(.trailing, 12)
+                .padding(.top, 4)
+            }
+
             ScrollViewReader { proxy in
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 6) {
@@ -71,6 +88,15 @@ struct ChannelChatView: View {
         }
         .onChange(of: channelIndex) { _, new in
             appState.clearChannelUnread(new)
+        }
+        .alert("Nachrichten löschen?", isPresented: $showDeleteConfirmation) {
+            Button("Löschen", role: .destructive) {
+                appState.clearChannelMessages(channelIndex)
+                coordinator.coreDataStore.deleteChannelMessages(channelIndex: channelIndex)
+            }
+            Button("Abbrechen", role: .cancel) {}
+        } message: {
+            Text("Alle Nachrichten in diesem Kanal werden unwiderruflich gelöscht.")
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a "Nachrichten löschen" (delete messages) trash button at the top of each channel chat view
- Same button added to DM conversation views
- Both show a confirmation dialog before deleting
- Clears messages from both in-memory state and CoreData

Fixes #8

## Test plan
- [ ] Open a channel with messages, click the trash button, confirm → messages cleared
- [ ] Cancel the confirmation → messages remain
- [ ] Button is disabled when no messages exist
- [ ] Same behavior in DM conversations

🤖 Generated with [Claude Code](https://claude.com/claude-code)