### PR TITLE
fix: Improve encrypted message UX with clearer explanation

### DIFF
--- a/MeshHessen/Localizable.xcstrings
+++ b/MeshHessen/Localizable.xcstrings
@@ -42,12 +42,12 @@
         }
       }
     },
-    "[Encrypted message — PSK required]" : {
+    "[Encrypted — channel key not configured on this device]" : {
       "localizations" : {
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "[Verschlüsselte Nachricht — PSK erforderlich]"
+            "value" : "[Verschlüsselt — Kanalschlüssel auf diesem Gerät nicht konfiguriert]"
           }
         }
       }

--- a/MeshHessen/Services/MeshtasticProtocolService.swift
+++ b/MeshHessen/Services/MeshtasticProtocolService.swift
@@ -372,7 +372,7 @@ final class MeshtasticProtocolService {
                 let msg = MessageItem(
                     packetId: packet.id,
                     time: ts, from: from, fromId: packet.from, toId: packet.to,
-                    message: String(localized: "[Encrypted message — PSK required]"),
+                    message: String(localized: "[Encrypted — channel key not configured on this device]"),
                     channelIndex: chIndex >= 0 ? chIndex : 0,
                     channelName: chName,
                     isEncrypted: true, isViaMqtt: packet.viaMqtt

--- a/MeshHessen/Views/ChannelChatView.swift
+++ b/MeshHessen/Views/ChannelChatView.swift
@@ -159,6 +159,7 @@ private struct MessageBubble: View {
                     Image(systemName: "lock.fill")
                         .foregroundStyle(.secondary)
                         .font(.caption)
+                        .help("Verschlüsselt — Kanalschlüssel (PSK) nicht konfiguriert")
                     Text(message.message)
                         .italic()
                         .foregroundStyle(.secondary)


### PR DESCRIPTION
## Summary
- Changed encrypted message text from "[PSK required]" to "[channel key not configured on this device]"
- Added tooltip on the lock icon explaining the encryption situation
- Updated German localization accordingly

Fixes #10

## Test plan
- [ ] Connect to a mesh where some channels use encryption keys you don't have
- [ ] Verify the new message text appears: "Verschlüsselt — Kanalschlüssel auf diesem Gerät nicht konfiguriert"
- [ ] Hover over the lock icon to see the tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)