### PR TITLE
fix: Fix map source selection and tile overlay visibility

### DIFF
--- a/MeshHessen/Views/MapView.swift
+++ b/MeshHessen/Views/MapView.swift
@@ -122,6 +122,13 @@ struct MapView: View {
         .onChange(of: mapStyle) { _, newStyle in
             SettingsService.shared.mapSource = newStyle.settingsValue
         }
+        .onAppear {
+            // Sync with settings in case it was changed from the Settings pane
+            let fromSettings = MapStyle.from(settingsValue: SettingsService.shared.mapSource)
+            if mapStyle != fromSettings {
+                mapStyle = fromSettings
+            }
+        }
         .onChange(of: appState.mapFocusNodeId) { _, newValue in
             // Clear focus after MapView processes it
             if let nodeId = newValue,
@@ -229,7 +236,7 @@ struct MeshMapViewRepresentable: NSViewRepresentable {
             case .dark: template = settings.osmDarkTileUrl
             }
             let overlay = CachedTileOverlay(urlTemplate: template, layer: style.rawValue)
-            overlay.canReplaceMapContent = false
+            overlay.canReplaceMapContent = true
             map.addOverlay(overlay, level: .aboveRoads)
             tileOverlay = overlay
         }


### PR DESCRIPTION
## Summary
- Set `canReplaceMapContent = true` so custom tile overlays fully replace the Apple Maps base layer, making style changes clearly visible
- Added `onAppear` sync so the map style picker reflects changes made in the Settings pane

Fixes #12

## Test plan
- [ ] Open the Map tab and use the segmented picker (Street / Topo / Dark)
- [ ] Verify each style shows a distinctly different map
- [ ] Change map source in Settings → Map and verify the Map tab updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)