### PR TITLE
feat: Add extended emoji reactions (32 emojis)

### DIFF
--- a/MeshHessen/AppCoordinator.swift
+++ b/MeshHessen/AppCoordinator.swift
@@ -141,6 +141,10 @@ final class AppCoordinator {
         await protocol_.sendSOSAlert(customText)
     }
 
+    func sendEmojiReaction(_ emoji: String, toPacketId: UInt32, toNodeId: UInt32 = 0xFFFFFFFF, channelIndex: Int = 0) async {
+        await protocol_.sendEmojiReaction(emoji, toPacketId: toPacketId, toNodeId: toNodeId, channelIndex: channelIndex)
+    }
+
     func updateOwner(shortName: String, longName: String) async {
         await protocol_.setOwner(shortName: shortName, longName: longName)
     }

--- a/MeshHessen/AppState.swift
+++ b/MeshHessen/AppState.swift
@@ -186,6 +186,20 @@ final class AppState {
         return nil
     }
 
+    func addReaction(emoji: String, from senderId: UInt32, toPacketId: UInt32) {
+        if let allIndex = packetIdToAllIndex[toPacketId] {
+            allMessages[allIndex].addReaction(emoji: emoji, from: senderId)
+            let channelIndex = allMessages[allIndex].channelIndex
+            if let channelMsgIdx = channelMessages[channelIndex]?.firstIndex(where: { $0.packetId == toPacketId }) {
+                channelMessages[channelIndex]?[channelMsgIdx].addReaction(emoji: emoji, from: senderId)
+            }
+        }
+        for key in dmConversations.keys {
+            guard let msgIdx = dmConversations[key]?.messages.firstIndex(where: { $0.packetId == toPacketId }) else { continue }
+            dmConversations[key]?.messages[msgIdx].addReaction(emoji: emoji, from: senderId)
+        }
+    }
+
     func updateDeliveryState(requestId: UInt32, state: MessageDeliveryState) {
         if let allIndex = packetIdToAllIndex[requestId] {
             allMessages[allIndex].deliveryState = state

--- a/MeshHessen/Models/MeshEnums.swift
+++ b/MeshHessen/Models/MeshEnums.swift
@@ -283,6 +283,25 @@ enum BluetoothMode: Int, CaseIterable, Identifiable {
 
 // MARK: - Tapback / Emoji Reactions
 
+/// Extended emoji reaction set (32 emojis in 4×8 grid)
+enum EmojiReaction {
+    /// All available reaction emojis, arranged in a 4×8 grid
+    static let allEmojis: [String] = [
+        // Row 1
+        "👍", "👎", "❤️", "😂", "😮", "😢", "😡", "🔥",
+        // Row 2
+        "👋", "🎉", "🤔", "👀", "💯", "🙏", "🤝", "💪",
+        // Row 3
+        "⚡", "✅", "❌", "⚠️", "📍", "🔔", "⭐", "💬",
+        // Row 4
+        "‼️", "❓", "💩", "🫡", "🤣", "😎", "🥳", "☠️",
+    ]
+
+    static let columns = 8
+    static let rows = 4
+}
+
+/// Legacy Tapback enum for backward compatibility
 enum Tapback: Int, CaseIterable, Identifiable {
     case wave = 0
     case heart = 1

--- a/MeshHessen/Models/MessageItem.swift
+++ b/MeshHessen/Models/MessageItem.swift
@@ -26,6 +26,29 @@ struct MessageItem: Identifiable {
     var hasAlertBell: Bool = false
     var deliveryState: MessageDeliveryState = .none
 
+    /// Emoji reactions: emoji string → list of sender node IDs
+    var reactionsByEmoji: [String: [UInt32]] = [:]
+
     /// true if this is a direct message (not broadcast)
     var isDirect: Bool { toId != 0xFFFFFFFF && toId != 0 }
+
+    /// Add a reaction from a sender
+    mutating func addReaction(emoji: String, from senderId: UInt32) {
+        var senders = reactionsByEmoji[emoji, default: []]
+        if !senders.contains(senderId) {
+            senders.append(senderId)
+            reactionsByEmoji[emoji] = senders
+        }
+    }
+
+    /// Remove a reaction from a sender
+    mutating func removeReaction(emoji: String, from senderId: UInt32) {
+        reactionsByEmoji[emoji]?.removeAll { $0 == senderId }
+        if reactionsByEmoji[emoji]?.isEmpty == true {
+            reactionsByEmoji.removeValue(forKey: emoji)
+        }
+    }
+
+    /// Whether this message has any reactions
+    var hasReactions: Bool { !reactionsByEmoji.isEmpty }
 }

--- a/MeshHessen/Views/ChannelChatView.swift
+++ b/MeshHessen/Views/ChannelChatView.swift
@@ -43,7 +43,17 @@ struct ChannelChatView: View {
                                 isMine: msg.fromId == appState.myNodeInfo?.nodeId,
                                 protocolReady: appState.protocolReady,
                                 showColorDot: true,
-                                showMqttIndicator: true
+                                showMqttIndicator: true,
+                                onReaction: msg.packetId != nil ? { emoji in
+                                    Task {
+                                        await coordinator.sendEmojiReaction(
+                                            emoji,
+                                            toPacketId: msg.packetId!,
+                                            toNodeId: 0xFFFFFFFF,
+                                            channelIndex: channelIndex
+                                        )
+                                    }
+                                } : nil
                             )
                             .id(msg.id)
                         }

--- a/MeshHessen/Views/DMWindowView.swift
+++ b/MeshHessen/Views/DMWindowView.swift
@@ -110,7 +110,17 @@ private struct DMConversationView: View {
                         ForEach(conversation.messages) { msg in
                             MessageBubbleView(
                                 message: msg,
-                                isMine: msg.fromId == appState.myNodeInfo?.nodeId
+                                isMine: msg.fromId == appState.myNodeInfo?.nodeId,
+                                onReaction: msg.packetId != nil ? { emoji in
+                                    Task {
+                                        await coordinator.sendEmojiReaction(
+                                            emoji,
+                                            toPacketId: msg.packetId!,
+                                            toNodeId: conversation.id,
+                                            channelIndex: 0
+                                        )
+                                    }
+                                } : nil
                             )
                             .id(msg.id)
                         }


### PR DESCRIPTION
## Summary
- Add `EmojiReaction` with 32 emojis in 4×8 grid and emoji picker popover
- Add reaction tracking to `MessageItem` with `reactionsByEmoji` dictionary
- Protocol support via `data.emoji` + `data.replyID` fields (portnum 1)
- Reaction pills displayed below message bubbles in channels and DMs

## Test plan
- [ ] Long-press message → context menu shows 4 quick reactions + "More Reactions..."
- [ ] "More Reactions..." opens 4×8 emoji grid popover
- [ ] Sending a reaction shows pill below the message
- [ ] Incoming reactions from other nodes appear as pills
- [ ] Reactions work in both channel messages and DMs

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)