### PR TITLE
feat: Add traceroute

### DIFF
--- a/MeshHessen/AppCoordinator.swift
+++ b/MeshHessen/AppCoordinator.swift
@@ -145,6 +145,14 @@ final class AppCoordinator {
         await protocol_.sendEmojiReaction(emoji, toPacketId: toPacketId, toNodeId: toNodeId, channelIndex: channelIndex)
     }
 
+    func sendTraceroute(to nodeId: UInt32) async {
+        await protocol_.sendTraceroute(to: nodeId)
+    }
+
+    var tracerouteResults: [TracerouteResult] {
+        protocol_.tracerouteResults
+    }
+
     func updateOwner(shortName: String, longName: String) async {
         await protocol_.setOwner(shortName: shortName, longName: longName)
     }

--- a/MeshHessen/Models/TracerouteResult.swift
+++ b/MeshHessen/Models/TracerouteResult.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+/// Represents the result of a traceroute operation
+struct TracerouteResult: Identifiable, Codable {
+    let id: UUID
+    let requestTime: Date
+    let targetNodeId: UInt32
+    let targetName: String
+    let hops: [TracerouteHop]
+    var responseTime: Date?
+
+    /// Total round-trip time in milliseconds
+    var roundTripMs: Int? {
+        guard let response = responseTime else { return nil }
+        return Int(response.timeIntervalSince(requestTime) * 1000)
+    }
+
+    init(targetNodeId: UInt32, targetName: String, hops: [TracerouteHop] = [], responseTime: Date? = nil) {
+        self.id = UUID()
+        self.requestTime = Date()
+        self.targetNodeId = targetNodeId
+        self.targetName = targetName
+        self.hops = hops
+        self.responseTime = responseTime
+    }
+}
+
+/// A single hop in a traceroute
+struct TracerouteHop: Identifiable, Codable {
+    let id: UUID
+    let nodeId: UInt32
+    let nodeName: String
+    let snr: Float?
+    let latitude: Double?
+    let longitude: Double?
+    let viaMqtt: Bool
+
+    init(nodeId: UInt32, nodeName: String, snr: Float? = nil,
+         latitude: Double? = nil, longitude: Double? = nil, viaMqtt: Bool = false) {
+        self.id = UUID()
+        self.nodeId = nodeId
+        self.nodeName = nodeName
+        self.snr = snr
+        self.latitude = latitude
+        self.longitude = longitude
+        self.viaMqtt = viaMqtt
+    }
+
+    /// Distance to the next hop (set externally)
+    var distanceToNext: Double?
+}
+
+/// Manages traceroute results persistence
+final class TracerouteStore {
+    static let shared = TracerouteStore()
+
+    private let fileManager = FileManager.default
+
+    private var storageDirectory: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("MeshHessen/traceroutes", isDirectory: true)
+    }
+
+    private init() {
+        try? fileManager.createDirectory(at: storageDirectory, withIntermediateDirectories: true)
+    }
+
+    func save(_ result: TracerouteResult) {
+        let fileURL = storageDirectory.appendingPathComponent("\(result.id.uuidString).json")
+        guard let data = try? JSONEncoder().encode(result) else { return }
+        try? data.write(to: fileURL)
+    }
+
+    func loadAll() -> [TracerouteResult] {
+        guard let files = try? fileManager.contentsOfDirectory(atPath: storageDirectory.path) else { return [] }
+        return files.compactMap { filename -> TracerouteResult? in
+            guard filename.hasSuffix(".json") else { return nil }
+            let fileURL = storageDirectory.appendingPathComponent(filename)
+            guard let data = try? Data(contentsOf: fileURL) else { return nil }
+            return try? JSONDecoder().decode(TracerouteResult.self, from: data)
+        }.sorted { $0.requestTime > $1.requestTime }
+    }
+
+    func delete(_ result: TracerouteResult) {
+        let fileURL = storageDirectory.appendingPathComponent("\(result.id.uuidString).json")
+        try? fileManager.removeItem(at: fileURL)
+    }
+}

--- a/MeshHessen/Views/NodeInfoSheet.swift
+++ b/MeshHessen/Views/NodeInfoSheet.swift
@@ -24,6 +24,7 @@ struct NodeInfoSheet: View {
     @State private var ownerShortName: String = ""
     @State private var ownerLongName: String = ""
     @State private var isSavingOwner = false
+    @State private var showTraceroute = false
 
     private var isOwnNode: Bool {
         appState.myNodeInfo?.nodeId == node.id
@@ -42,6 +43,16 @@ struct NodeInfoSheet: View {
                         .foregroundStyle(.secondary)
                 }
                 Spacer()
+                if !isOwnNode {
+                    Button {
+                        showTraceroute = true
+                    } label: {
+                        Image(systemName: "arrow.triangle.swap")
+                            .foregroundStyle(.secondary)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Traceroute")
+                }
                 Button {
                     node.isPinned.toggle()
                     coordinator.coreDataStore.updateNodePinState(nodeId: node.id, isPinned: node.isPinned)
@@ -214,6 +225,9 @@ struct NodeInfoSheet: View {
         }
         .padding(20)
         .frame(minWidth: 420, minHeight: 320)
+        .sheet(isPresented: $showTraceroute) {
+            TracerouteSheet(targetNodeId: node.id, targetName: node.name)
+        }
         .onAppear {
             // Load persisted values from UserDefaults, falling back to in-memory model
             let savedColor = SettingsService.shared.colorHex(for: node.id)

--- a/MeshHessen/Views/NodesTabView.swift
+++ b/MeshHessen/Views/NodesTabView.swift
@@ -8,6 +8,7 @@ struct NodesTabView: View {
     @State private var sortOrder = [KeyPathComparator(\NodeInfo.name)]
     @State private var selectedNodeId: UInt32?
     @State private var showNodeInfo: NodeInfo?
+    @State private var tracerouteTarget: NodeInfo?
 
     private var sortedNodes: [NodeInfo] {
         let sorted = appState.filteredNodes.sorted(using: sortOrder)
@@ -126,6 +127,9 @@ struct NodesTabView: View {
                     NSPasteboard.general.clearContents()
                     NSPasteboard.general.setString(node.nodeId, forType: .string)
                 }
+                if node.id != appState.myNodeInfo?.nodeId {
+                    Button("Traceroute") { tracerouteTarget = node }
+                }
                 Divider()
                 Menu("Set Color") {
                     ForEach(nodeColorPresets, id: \.hex) { preset in
@@ -149,6 +153,9 @@ struct NodesTabView: View {
         }
         .sheet(item: $showNodeInfo) { node in
             NodeInfoSheet(node: node)
+        }
+        .sheet(item: $tracerouteTarget) { node in
+            TracerouteSheet(targetNodeId: node.id, targetName: node.name)
         }
         .navigationTitle("Nodes")
     }

--- a/MeshHessen/Views/TracerouteSheet.swift
+++ b/MeshHessen/Views/TracerouteSheet.swift
@@ -1,0 +1,154 @@
+import SwiftUI
+import MapKit
+
+/// Sheet showing traceroute results for a node, with hop table and map visualization.
+struct TracerouteSheet: View {
+    @Environment(AppCoordinator.self) private var coordinator
+    @Environment(\.dismiss) private var dismiss
+
+    let targetNodeId: UInt32
+    let targetName: String
+
+    @State private var isRequesting = false
+    @State private var results: [TracerouteResult] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            // Header
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Traceroute")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    Text("Target: \(targetName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button {
+                    isRequesting = true
+                    Task {
+                        await coordinator.sendTraceroute(to: targetNodeId)
+                        // Wait a bit then refresh results
+                        try? await Task.sleep(for: .seconds(2))
+                        results = coordinator.tracerouteResults.filter { $0.targetNodeId == targetNodeId }
+                        isRequesting = false
+                    }
+                } label: {
+                    if isRequesting {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Run Traceroute", systemImage: "arrow.triangle.swap")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isRequesting)
+
+                Button("Done") { dismiss() }
+                    .keyboardShortcut(.return, modifiers: .command)
+            }
+
+            Divider()
+
+            if results.isEmpty {
+                ContentUnavailableView(
+                    "No Traceroute Results",
+                    systemImage: "arrow.triangle.swap",
+                    description: Text("Run a traceroute to see the network path to this node.")
+                )
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 12) {
+                        ForEach(results) { result in
+                            TracerouteResultCard(result: result)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(20)
+        .frame(minWidth: 500, minHeight: 400)
+        .onAppear {
+            results = coordinator.tracerouteResults.filter { $0.targetNodeId == targetNodeId }
+            if results.isEmpty {
+                results = TracerouteStore.shared.loadAll().filter { $0.targetNodeId == targetNodeId }
+            }
+        }
+    }
+}
+
+/// Card showing a single traceroute result
+private struct TracerouteResultCard: View {
+    let result: TracerouteResult
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(result.requestTime, format: .dateTime.hour().minute().second())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                if let rtt = result.roundTripMs {
+                    Text("RTT: \(rtt) ms")
+                        .font(.caption)
+                        .foregroundStyle(.green)
+                }
+                Spacer()
+                Text("\(result.hops.count) hop(s)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            // Hop table
+            ForEach(Array(result.hops.enumerated()), id: \.element.id) { index, hop in
+                HStack(spacing: 12) {
+                    Text("\(index + 1)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .frame(width: 20, alignment: .trailing)
+
+                    if hop.viaMqtt {
+                        Image(systemName: "antenna.radiowaves.left.and.right")
+                            .font(.caption2)
+                            .foregroundStyle(.orange)
+                    }
+
+                    Text(hop.nodeName)
+                        .font(.callout)
+                        .fontWeight(.medium)
+
+                    Spacer()
+
+                    if let snr = hop.snr {
+                        Text(String(format: "%.1f dB", snr))
+                            .font(.caption)
+                            .foregroundStyle(snrColor(snr))
+                    }
+
+                    Text(String(format: "!%08x", hop.nodeId))
+                        .font(.system(.caption2, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                }
+                .padding(.vertical, 2)
+
+                if index < result.hops.count - 1 {
+                    HStack {
+                        Spacer().frame(width: 20)
+                        Image(systemName: "arrow.down")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                            .padding(.leading, 4)
+                    }
+                }
+            }
+        }
+        .padding(12)
+        .background(Color.secondary.opacity(0.06))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func snrColor(_ snr: Float) -> Color {
+        if snr >= 5 { return .green }
+        if snr >= 0 { return .orange }
+        return .red
+    }
+}


### PR DESCRIPTION
## Summary
- Create `TracerouteResult` model with hops, SNR, RTT, and `TracerouteStore` for JSON persistence
- Enhanced `handleTraceroutePacket()` with full hop parsing and zigzag-encoded SNR extraction
- `TracerouteSheet` UI showing hop table with node names, SNR coloring, and round-trip time
- Traceroute button in `NodeInfoSheet` header and `NodesTabView` context menu

## Test plan
- [ ] Click traceroute button in NodeInfoSheet → TracerouteSheet opens
- [ ] Run traceroute → hops displayed with node names and SNR values
- [ ] RTT shown in green for successful routes
- [ ] Results persist across app restarts (JSON storage)
- [ ] Context menu "Traceroute" in NodesTabView works

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)